### PR TITLE
Take into account cfs quota and affinity.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,35 @@ version = 3
 [[package]]
 name = "amicontained"
 version = "0.1.0"
+dependencies = [
+ "nix",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "libc"
+version = "0.2.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["staticlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nix = { version = "0.27.1", features = ["sched"] }

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lib:
 .PHONY: check
 check: example
 	RUST_BACKTRACE=1 cargo test
-	bats -t $(patsubst %,test/%.bats,$(TEST))
+	sudo bats -t $(patsubst %,test/%.bats,$(TEST))
 
 %: %.c lib
 	gcc -static -o $@ $< -I./include -L./target/release -lamicontained

--- a/test/cpusets.bats
+++ b/test/cpusets.bats
@@ -1,7 +1,7 @@
 load helpers
 
 function setup() {
-    setup_fake_rootfs
+    make_cgroup
 }
 
 function teardown() {
@@ -9,16 +9,28 @@ function teardown() {
 }
 
 @test "cpuset range" {
-    echo 0-1 > "$TEMP_DIR/sys/fs/cgroup/cpuset.cpus.effective"
-    check_num_cpus 2
+    echo 0-1 > "$CGROUP_DIR/cpuset.cpus"
+    check_num_cpus 2 2
 }
 
 @test "cpuset single" {
-    echo 2 > "$TEMP_DIR/sys/fs/cgroup/cpuset.cpus.effective"
-    check_num_cpus 1
+    echo 2 > "$CGROUP_DIR/cpuset.cpus"
+    check_num_cpus 1 1
 }
 
 @test "cpuset multiple" {
-    echo 1,2 > "$TEMP_DIR/sys/fs/cgroup/cpuset.cpus.effective"
-    check_num_cpus 2
+    echo 1,2 > "$CGROUP_DIR/cpuset.cpus"
+    check_num_cpus 2 2
+}
+
+@test "cpu.max set" {
+    echo 0-1 > "$CGROUP_DIR/cpuset.cpus"
+    echo 100000 100000 > "$CGROUP_DIR/cpu.max"
+    check_num_cpus 2 1
+}
+
+@test "cpu.max unset" {
+    echo 0-1 > "$CGROUP_DIR/cpuset.cpus"
+    echo max 100000 > "$CGROUP_DIR/cpu.max"
+    check_num_cpus 2 2
 }


### PR DESCRIPTION
In addition to cpusets, cpu affinity can constrain cpus so this adds looking at sched_getaffinity in addition to effective cpus in the cgroup.

For the recommended threads, we additionally take into account cfs quota doing similar quota->cpu math as systemd and lxcfs.