### PR TITLE
fix: reduce libamicontained.a size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 nix = { version = "0.27.1", features = ["sched"] }
+
+[profile.release]
+lto = "thin"


### PR DESCRIPTION
This commit reduces binary size from 18Mb to 5.4Mb
- add a release profile to Cargo.toml.
- use [lto](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) attribute and set it to `thin`.

NB: Using [strip](https://man7.org/linux/man-pages/man1/strip.1.html) size can be brought down to 1.5Mb ```strip target/release/libamicontained.a```.